### PR TITLE
ユーザー更新の FormRequest 化と本人制限

### DIFF
--- a/app/Http/Controllers/v1/UserController.php
+++ b/app/Http/Controllers/v1/UserController.php
@@ -3,10 +3,10 @@
 namespace App\Http\Controllers\v1;
 
 use App\Http\Controllers\Controller;
+use App\Http\Requests\UpdateUserRequest;
 use App\Http\Resources\UserResource;
 use App\Models\User;
 use Illuminate\Http\Request;
-use Illuminate\Validation\Rule;
 
 class UserController extends Controller
 {
@@ -24,15 +24,9 @@ class UserController extends Controller
         return new UserResource($request->user());
     }
 
-    public function update(Request $request, User $user)
+    public function update(UpdateUserRequest $request, User $user)
     {
-        $validated = $request->validate([
-            'name' => 'sometimes|string|max:255',
-            'email' => ['sometimes', 'string', 'email', 'max:255', Rule::unique('users')->ignore($user->id)],
-            'password' => 'sometimes|string|min:8|confirmed',
-        ]);
-
-        $user->update($validated);
+        $user->update($request->validated());
 
         return new UserResource($user);
     }

--- a/app/Http/Requests/UpdateUserRequest.php
+++ b/app/Http/Requests/UpdateUserRequest.php
@@ -1,0 +1,32 @@
+<?php
+
+namespace App\Http\Requests;
+
+use Illuminate\Foundation\Http\FormRequest;
+use Illuminate\Validation\Rule;
+
+class UpdateUserRequest extends FormRequest
+{
+    public function authorize(): bool
+    {
+        $auth = $this->user();
+        $target = $this->route('user');
+
+        return $auth !== null && $auth->is($target);
+    }
+
+    public function rules(): array
+    {
+        return [
+            'name' => 'sometimes|string|max:255',
+            'email' => [
+                'sometimes',
+                'string',
+                'email',
+                'max:255',
+                Rule::unique('users')->ignore($this->route('user')),
+            ],
+            'password' => 'sometimes|string|min:8|confirmed',
+        ];
+    }
+}


### PR DESCRIPTION
## 概要
ユーザー更新 API（`UserController::update`）のバリデーションを `UpdateUserRequest` に移し、**更新は本人のみ**（認証ユーザーとルートの `{user}` が一致する場合のみ）可能にする。

## 変更内容
- `app/Http/Requests/UpdateUserRequest.php` を新規追加（`rules` / `authorize`）
- `UserController::update` は `->validated()` による更新に整理

## 挙動
- 本人でない、または未認証の更新リクエストは 403（Form Request の `authorize`）


Made with [Cursor](https://cursor.com)