### PR TITLE
chore: Docker PCOV と GitHub Actions CI

### DIFF
--- a/.docker/php/Dockerfile
+++ b/.docker/php/Dockerfile
@@ -13,6 +13,9 @@ RUN apt-get update && apt-get install -y \
 
 RUN docker-php-ext-install pdo_mysql mbstring exif pcntl bcmath gd opcache
 
+RUN pecl install pcov \
+    && docker-php-ext-enable pcov
+
 COPY --from=composer:latest /usr/bin/composer /usr/bin/composer
 COPY ./.docker/php/php.ini /usr/local/etc/php/
 

--- a/.docker/php/entrypoint.sh
+++ b/.docker/php/entrypoint.sh
@@ -6,5 +6,10 @@ chmod -R 775 /var/www/html/storage
 
 composer install
 
+# docker compose run で渡したコマンドを実行（例: php artisan test --coverage）
+if [ "$#" -gt 0 ]; then
+    exec "$@"
+fi
+
 # PHP-FPMを起動
 exec php-fpm

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,0 +1,45 @@
+name: Tests
+
+on:
+  push:
+    branches:
+      - main
+      - master
+  pull_request:
+    types: [opened, synchronize, reopened, ready_for_review]
+
+jobs:
+  php-tests:
+    if: github.event_name != 'pull_request' || github.event.pull_request.draft == false
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup PHP
+        uses: shivammathur/setup-php@v2
+        with:
+          php-version: "8.3"
+          extensions: mbstring, dom, fileinfo, pdo_sqlite, sqlite3, bcmath, gd
+          coverage: none
+
+      - name: Cache Composer dependencies
+        uses: actions/cache@v4
+        with:
+          path: vendor
+          key: ${{ runner.os }}-composer-${{ hashFiles('**/composer.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-composer-
+
+      - name: Install Composer dependencies
+        run: composer install --no-interaction --prefer-dist --optimize-autoloader --no-progress
+
+      - name: Prepare environment
+        run: |
+          cp .env.example .env
+          php artisan key:generate --ansi --force
+          php artisan jwt:secret --ansi --force
+
+      - name: Run tests
+        run: php artisan test


### PR DESCRIPTION
## 概要
`main` 先端をベースにした PR です（ユーザー更新の FormRequest 化は #8 で `main` に取り込み済みのため、この PR からは除外）。

## 変更内容
- **Docker**: PCOV を追加し、`docker compose run` で `php artisan test --coverage` 等が実行できるよう entrypoint を調整
- **GitHub Actions**: `php artisan test` を実行（ドラフト PR はスキップ）

## 確認
- CI が通ること
- ローカル: `docker compose build laravel.test` のあと `docker compose run --rm --no-deps laravel.test php artisan test`