### PR TITLE
feat: タスクのタイトル50文字・説明300文字の上限バリデーションを追加

### DIFF
--- a/app/Http/Requests/StoreTaskRequest.php
+++ b/app/Http/Requests/StoreTaskRequest.php
@@ -14,9 +14,9 @@ class StoreTaskRequest extends FormRequest
     public function rules(): array
     {
         return [
-            'title' => 'required|string|max:255',
+            'title' => 'required|string|max:50',
             'is_public' => 'required|boolean',
-            'description' => 'nullable|string',
+            'description' => 'nullable|string|max:300',
             'expired_at' => 'nullable|date',
             'assigned_user_ids' => 'nullable|array',
             'assigned_user_ids.*' => 'required|integer|exists:users,id',

--- a/app/Http/Requests/UpdateTaskRequest.php
+++ b/app/Http/Requests/UpdateTaskRequest.php
@@ -14,10 +14,10 @@ class UpdateTaskRequest extends FormRequest
     public function rules(): array
     {
         return [
-            'title' => 'sometimes|string|max:255',
+            'title' => 'sometimes|string|max:50',
             'is_public' => 'sometimes|boolean',
             'expired_at' => 'nullable|date',
-            'description' => 'nullable|string',
+            'description' => 'nullable|string|max:300',
             'is_done' => 'sometimes|boolean',
             'assigned_user_ids' => 'nullable|array',
             'assigned_user_ids.*' => 'required|integer|exists:users,id',


### PR DESCRIPTION
## 概要

タスクの登録・更新時に、タイトルと説明の文字数上限バリデーションを追加しました。

| 項目 | 変更前 | 変更後 |
| --- | --- | --- |
| `title` | `max:255` | `max:50` |
| `description` | 上限なし | `max:300` |

## 変更ファイル

- `app/Http/Requests/StoreTaskRequest.php`（タスク登録）
- `app/Http/Requests/UpdateTaskRequest.php`（タスク更新）

## 補足

### マイグレーションは不要

DB カラムは `title` が `string`（varchar(255)）、`description` が `text` のため、50文字・300文字は問題なく収まります。スキーマ変更は行っていません。

### 既存データへの影響（要確認）

`title` はこれまで最大255文字を許容していたため、**既に50文字を超えるタスクが保存されている可能性があります。** その場合、更新APIで `title` を送信するとバリデーションエラーになります。既存データの確認・移行が必要かはご判断ください。

### テスト

`StoreTaskRequest` / `UpdateTaskRequest` を参照する既存テストが見つからなかったため、テストの追加・修正は行っていません。必要であれば別途対応します。

🤖 Generated with [Claude Code](https://claude.com/claude-code)