### PR TITLE
chore: Dependabot による依存関係の自動更新を追加

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,42 @@
+# Dependabot version updates の設定
+# https://docs.github.com/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file
+
+version: 2
+updates:
+  # Composer (PHP) の依存更新
+  - package-ecosystem: "composer"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+      timezone: "Asia/Tokyo"
+    open-pull-requests-limit: 10
+    groups:
+      # require-dev をまとめて1つのPRにする
+      dev-dependencies:
+        dependency-type: "development"
+      # 本番依存は minor と patch をグループ化
+      production-minor-patch:
+        dependency-type: "production"
+        update-types:
+          - "minor"
+          - "patch"
+    ignore:
+      # PHP 本体のバージョン制約は手動で管理する
+      - dependency-name: "php"
+
+  # GitHub Actions の自動更新
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+      timezone: "Asia/Tokyo"
+
+  # Dockerfile のベースイメージ更新
+  - package-ecosystem: "docker"
+    directory: "/.docker/php"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+      timezone: "Asia/Tokyo"


### PR DESCRIPTION
## 概要

Laravel リポジトリにも Dependabot を導入し、依存関係の更新を自動化します。
`todo-frontend-react-v2` の設定と同じ方針・スタイルに揃えています。

## 対象

| ecosystem | 対象 | グループ化 |
|---|---|---|
| `composer` | `composer.json` | require-dev / 本番依存の minor+patch |
| `github-actions` | `.github/workflows/tests.yml` の actions | なし |
| `docker` | `.docker/php/Dockerfile` | なし |

いずれも週次(毎週月曜・Asia/Tokyo)実行です。

## 方針

- **本番依存の major は個別 PR**: `laravel/framework` の major などは破壊的変更を含むため、グループ化せず単独 PR で確認できるようにしています
- **`php` は ignore**: `"php": "^8.2"` は CI の PHP 8.3 やインフラ側と揃える必要があるため、Dependabot には触らせず手動管理とします
- **npm は対象外**: 当リポジトリに `package.json` は存在しないため

## 補足

- Composer の更新 PR では `composer.lock` が変わるため CI の vendor キャッシュはミスしますが、想定どおりの挙動です
- リポジトリ側で Dependabot version updates の有効化が別途必要な場合があります

🤖 Generated with [Claude Code](https://claude.com/claude-code)