### PR TITLE
refactor: ネストした apiResource に明示的なルート名を付与

### DIFF
--- a/routes/api.php
+++ b/routes/api.php
@@ -16,7 +16,10 @@ Route::group(['prefix' => 'v1'], function () {
         Route::get('users/me', [UserController::class, 'me']);
         Route::apiResource('users', UserController::class)->only(['index', 'update', 'destroy']);
         Route::apiResource('tasks', TaskController::class);
-        Route::apiResource('tasks/{task}/actions', TaskActionController::class);
-        Route::apiResource('users/me/tasks', UserMeTaskController::class)->only('index');
+        Route::apiResource('tasks/{task}/actions', TaskActionController::class)
+            ->names('tasks.actions');
+        Route::apiResource('users/me/tasks', UserMeTaskController::class)
+            ->only('index')
+            ->names('users.me.tasks');
     });
 });


### PR DESCRIPTION
## 概要

`routes/api.php` のネストした `apiResource` 定義に、`names()` で明示的なルート名を付与しました。

## 背景

`tasks/{task}/actions` と `users/me/tasks` は URI にパスパラメータやネストを含むため、Laravel が自動生成するルート名がそのまま URI 由来の不自然なものになっていました。`route()` ヘルパーやテストから参照しづらいため、意図した命名に揃えます。

## 変更内容

| ルート | ルート名 |
| --- | --- |
| `tasks/{task}/actions` | `tasks.actions.*` |
| `users/me/tasks` | `users.me.tasks.index` |

## 動作確認

- `php artisan route:list --path=api` で意図したルート名になっていることを確認
- `php artisan test` → 18 passed (49 assertions)

🤖 Generated with [Claude Code](https://claude.com/claude-code)