### PR TITLE
ci: Dependency Review ActionでPR時に脆弱性をブロックする

### DIFF
--- a/.github/workflows/dependency-review.yml
+++ b/.github/workflows/dependency-review.yml
@@ -1,0 +1,31 @@
+name: Dependency Review
+
+on:
+  pull_request:
+    types:
+      - opened
+      - synchronize
+      - reopened
+      - ready_for_review
+    paths:
+      - composer.json
+      - composer.lock
+      - .github/workflows/dependency-review.yml
+
+permissions:
+  contents: read
+
+jobs:
+  dependency-review:
+    if: ${{ github.event.pull_request.draft == false }}
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v7
+
+      - name: Dependency Review
+        uses: actions/dependency-review-action@v4
+        with:
+          fail-on-severity: high
+          deny-licenses: GPL-3.0, AGPL-3.0


### PR DESCRIPTION
## 概要

[KadoProG/react-calendar-app#75](https://github.com/KadoProG/react-calendar-app/issues/75) と同様に、Dependency Review Action を導入します。

PR で依存パッケージが追加・更新された際に、既知の脆弱性や許可されないライセンスを検出して失敗させます。

## 変更内容

`.github/workflows/dependency-review.yml` を追加。

- 起動条件: `pull_request` の `opened` / `synchronize` / `reopened` / `ready_for_review`（既存の tests.yml と同条件）
- draft PR ではスキップ
- `paths` により `composer.json` / `composer.lock` / 本ワークフロー自体の変更時のみ実行
- `fail-on-severity: high` — high 以上の脆弱性で失敗
- `deny-licenses: GPL-3.0, AGPL-3.0`

## 補足

- Dependency Review Action は依存グラフが有効なリポジトリでのみ動作します。プライベートリポジトリの場合は Settings → Code security → Dependency graph の有効化が必要です。
- 実際にマージをブロックするには、ブランチ保護ルールで `dependency-review` を required status check に追加する必要があります。ただし本ワークフローは `paths` フィルタを使っているため、依存ファイルを変更しない PR ではジョブが起動せず、required にするとチェックが pending のままマージできなくなる点にご注意ください。

🤖 Generated with [Claude Code](https://claude.com/claude-code)